### PR TITLE
Tailwind config performance improvements

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -5,12 +5,8 @@ module.exports = {
   purge: {
     enabled: true,
     content: [
-      "./**/*.html",
-      "./*.html",
-      "./**/*.js",
-      "./*.js",
-      "./**/*.svelte",
-      "./*.svelte",
+      "./src/**/*.js",
+      "./src/**/*.svelte",
     ],
     options: {
       safelist: [],


### PR DESCRIPTION
Hey,

I took a look at tailwind.config and it seems like the globs were more generous than they had to. Output CSS is smaller and should compile faster:

Before:
```
   ✅ Finished in 46 s
   📦 Size: 60.42KB
   💾 Saved to public/assets/styles/tailwind.css
```

After:
```
   ✅ Finished in 40 s
   📦 Size: 43.66KB
   💾 Saved to public/assets/styles/tailwind.css
```

---

If you are interested i also have on my local drive notus upgraded to newest tailwindcss running with JIT mode.
Result is even more spectacular, because it is another couple KB smaller (overall its 21KB smaller than current master), and compiles below half a second (before 46seconds).

```
   ✅ Finished in 439 ms
   📦 Size: 38.97KB
   💾 Saved to public/assets/styles/tailwind.css
```